### PR TITLE
Type connection edge positions

### DIFF
--- a/src/components/ConnectionEdge.tsx
+++ b/src/components/ConnectionEdge.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback } from 'react';
-import { BaseEdge, EdgeLabelRenderer, getBezierPath, Edge } from '@xyflow/react';
+import { BaseEdge, EdgeLabelRenderer, getBezierPath, Edge, type Position } from '@xyflow/react';
 import { BrainstormConnection } from '@/types/brainstorm';
 import { useComposerStore } from '@/hooks/useComposerStore';
 
@@ -15,8 +15,8 @@ interface ConnectionEdgeProps {
   sourceY: number;
   targetX: number;
   targetY: number;
-  sourcePosition: any;
-  targetPosition: any;
+  sourcePosition: Position;
+  targetPosition: Position;
   data: ConnectionEdgeData;
 }
 


### PR DESCRIPTION
## Summary
- import the Position type from `@xyflow/react` for connection edges
- type the connection edge props to use `Position` for source and target positions

## Testing
- `npm run lint` *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbe3d85b483209f736b69d0abd2a5