### PR TITLE
Remove duplicate business posts fetch

### DIFF
--- a/src/components/feeds/BusinessFeed.tsx
+++ b/src/components/feeds/BusinessFeed.tsx
@@ -70,10 +70,6 @@ export function BusinessFeed() {
     openComposer({});
   };
 
-  useEffect(() => {
-    fetchPosts('business');
-  }, []);
-
   // Filter posts based on current filters
   const filteredPosts = posts.filter(post => {
     const matchesSearch = !filters.search || 


### PR DESCRIPTION
## Summary
- remove the duplicate business feed fetch effect so posts load only once

## Testing
- npm run lint *(fails: pre-existing lint violations throughout the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cca6c3b1788320bb5918a0fb56eb8c